### PR TITLE
feat: added 17Moons as a contributor

### DIFF
--- a/Task1/intro.json
+++ b/Task1/intro.json
@@ -247,6 +247,15 @@
     "hacktoberfest_round": "first",
     "role": ["contributor"]
   },
+  {
+    "name": "Ngong Marcel",
+    "github_handle": "Marcel-star-ctrl",
+    "hacktoberfest_round": "second",
+    "role": [
+      "maintainer",
+      "contributor"
+    ]
+  },
 
 
 ]


### PR DESCRIPTION
there is one conflict coming with the user   {
    "name": "Ngong Marcel",
    "github_handle": "Marcel-star-ctrl",
    "hacktoberfest_round": "second",
    "role": [
      "maintainer",
      "contributor"
    ]
  },  his name is being shown on line 254 in the conflict but in latest pull it is at 274 , I don't know how to resolve it 